### PR TITLE
Feature/check code duplication

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -24,7 +24,7 @@ end
 def checkPmdInstalled
   installed = system("which pmd")
   if !installed
-    message("`pmd` not found. Install `pmd` to use Copy Paste Detector.")
+    message("`pmd` not found. Install `pmd` to use Copy Paste Detector. https://github.com/indigotech/danger/tree/master#pmdcopy-paste-detector")
   else
     checkCpd(@cpd_opts)
   end

--- a/Dangerfile
+++ b/Dangerfile
@@ -17,8 +17,8 @@ def checkCpd(opts)
 
   @minimum_tokens = 100
   @target_branch = ENV['TRAVIS_BRANCH'] || "develop"
-  @check_cpd = true if @language && @directory
-  message("Vars for Copy Paste Detector were not set") if !@check_cpd
+  @will_check_cpd = true if @language && @directory
+  message("Vars for Copy Paste Detector were not set") if !@will_check_cpd
 end
 
 def checkPmdInstalled
@@ -475,6 +475,6 @@ end
 checkPmdInstalled
 
 # Check if duplicated code increased
-if @check_cdp
+if @will_check_cpd
   warn("This PR has more duplicated code than your target branch, therefore it could have some code quality issues") if has_more_duplicated_code?
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -176,8 +176,12 @@ def run_cpd_on_current_branch
 end
 
 def run_cpd_on_target_branch
-  `git clone --depth 1 #{@ssh} --branch #{@target_branch} target-branch`
-  `pmd cpd --language #{@language} --minimum-tokens  #{@minimum_tokens} --files target-branch/#{@directory} --ignore-identifiers | grep tokens | wc -l`.to_i
+  dir = Dir.pwd
+  `mkdir target-branch`
+  `cp -r #{dir}/.git #{dir}/target-branch`
+  Dir.chdir "target-branch"
+  `git reset --hard origin/#{@target_branch}`
+  `pmd cpd --language #{@language} --minimum-tokens  #{@minimum_tokens} --files #{@directory} --ignore-identifiers | grep tokens | wc -l`.to_i
 end
 
 ########################

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,4 +1,6 @@
 require 'find'
+require 'fileutils'
+require 'tmpdir'
 
 if !defined? @platform
   warn("No platform was provided to perform platform specific assertions")
@@ -176,12 +178,13 @@ def run_cpd_on_current_branch
 end
 
 def run_cpd_on_target_branch
-  dir = Dir.pwd
-  `mkdir target-branch`
-  `cp -r #{dir}/.git #{dir}/target-branch`
-  Dir.chdir "target-branch"
-  `git reset --hard origin/#{@target_branch}`
-  `pmd cpd --language #{@language} --minimum-tokens  #{@minimum_tokens} --files #{@directory} --ignore-identifiers | grep tokens | wc -l`.to_i
+  dir_path = Dir.pwd
+  Dir.mktmpdir do |dir_tmp|
+    `cp -r #{dir_path}/.git #{dir_tmp}`
+    Dir.chdir dir_tmp
+    `git reset --hard origin/#{@target_branch}`
+    `pmd cpd --language #{@language} --minimum-tokens  #{@minimum_tokens} --files #{@directory} --ignore-identifiers | grep tokens | wc -l`.to_i
+  end
 end
 
 ########################

--- a/Dangerfile
+++ b/Dangerfile
@@ -7,14 +7,23 @@ if !defined? @platform
   @platform = "" # avoid future crashes
 end
 
-def willCheckCdp?(opts)
+def checkCpd(opts)
   @language = opts[:language]
   @directory = opts[:directory]
 
   @minimum_tokens = 100
   @target_branch = ENV['TRAVIS_BRANCH'] || "develop"
-  @check_cdp = true if @language && @directory
-  message("Vars for Copy Paste Detector were not set") if !@check_cdp
+  @check_cpd = true if @language && @directory
+  message("Vars for Copy Paste Detector were not set") if !@check_cpd
+end
+
+def checkPmdInstalled
+  installed = `brew ls --versions pmd`
+  if installed.empty?
+    message("`pmd` not found. Install `pmd` to use Copy Paste Detector.")
+  else
+    checkCpd(@cpd_opts)
+  end
 end
 
 ########################
@@ -86,7 +95,7 @@ def exceptionMessages(file)
   end
 end
 
-willCheckCdp?(@cdp_opts)
+checkPmdInstalled
 
 ########################
 #    NODE FUNCTIONS    #

--- a/Dangerfile
+++ b/Dangerfile
@@ -17,15 +17,6 @@ def checkCpd(opts)
   message("Vars for Copy Paste Detector were not set") if !@check_cpd
 end
 
-def checkPmdInstalled
-  installed = `brew ls --versions pmd`
-  if installed.empty?
-    message("`pmd` not found. Install `pmd` to use Copy Paste Detector.")
-  else
-    checkCpd(@cpd_opts)
-  end
-end
-
 ########################
 #   FUNCTIONS SECTION  #
 ########################
@@ -95,7 +86,7 @@ def exceptionMessages(file)
   end
 end
 
-checkPmdInstalled
+checkCpd(@cpd_opts)
 
 ########################
 #    NODE FUNCTIONS    #

--- a/Dangerfile
+++ b/Dangerfile
@@ -8,6 +8,8 @@ end
 if [@minimum_tokens, @language, @directory, @ssh, @target_branch].any? { |e| e.nil? }
   warn("Variables for checking duplicated code not defined, skipping this validation.")
   @check_cdp = false
+else
+  @check_cdp = true
 end
 
 ########################
@@ -77,11 +79,6 @@ def exceptionMessages(file)
   else
     message "One of modified files could not be read, does it really exist?"
   end
-end
-
-# Check if duplicated code increased
-if @check_cdp
-  warn("This PR has more duplicated code than your target branch, therefore it could have some code quality issues") if has_more_duplicated_code?
 end
 
 ########################
@@ -453,4 +450,9 @@ modified_files.each do |file|
   rescue
     exceptionMessages(file)
   end
+end
+
+# Check if duplicated code increased
+if @check_cdp
+  warn("This PR has more duplicated code than your target branch, therefore it could have some code quality issues") if has_more_duplicated_code?
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -17,6 +17,15 @@ def checkCpd(opts)
   message("Vars for Copy Paste Detector were not set") if !@check_cpd
 end
 
+def checkPmdInstalled
+  installed = system("which pmd")
+  if !installed
+    message("`pmd` not found. Install `pmd` to use Copy Paste Detector.")
+  else
+    checkCpd(@cpd_opts)
+  end
+end
+
 ########################
 #   FUNCTIONS SECTION  #
 ########################
@@ -86,7 +95,7 @@ def exceptionMessages(file)
   end
 end
 
-checkCpd(@cpd_opts)
+checkPmdInstalled
 
 ########################
 #    NODE FUNCTIONS    #
@@ -187,7 +196,7 @@ end
 def run_cpd_on_target_branch
   dir_path = Dir.pwd
   Dir.mkdir("tmp")
-  `cp -r #{dir_path}/.git tmp`
+  `cp -r "#{dir_path}"/.git tmp`
   Dir.chdir("tmp")
   `git reset --hard origin/#{@target_branch}`
   `pmd cpd --language #{@language} --minimum-tokens  #{@minimum_tokens} --files #{@directory} --ignore-identifiers | grep tokens | wc -l`.to_i

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ gem "danger", "4.2.1"
 1. Execute `$ bundle  install`
 1. Create a `Dangerfile` with
 ```ruby
+# Copy Paste Detector
+# Possible languages are "obejctivec", "swift", "java", "ruby", "ecmascript"(JavaScript)
+# Directory is your project folder name
+@cpd_opts = { language: "swift", directory: "App"}
 @platform = "nodejs" # Possible platforms are "nodejs", "ios", "android" and "web"
 danger.import_dangerfile(github: "indigotech/danger")
 ```
@@ -67,6 +71,7 @@ $ bundle exec danger --dangerfile=path/to/Dangerfile
 - [x] Warn when Amazon Secret Key is hardcoded
 - [x] Warn when `Dangerfile` was modified
 - [x] Warn when `http://` is used
+- [x] Warn for increase in code duplication detection
 
 ### Node
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ gem "danger", "4.2.1"
 danger.import_dangerfile(github: "indigotech/danger")
 ```
 
+### PMD/Copy Paste Detector
+
+If your project is running on Travis CI, you will need to add `pmd` installation in your `.travis.yml`
+```
+...
+install:
+- bundle install
+- brew install pmd
+...
+```
+
 ## Usage Locally
 
 ### Setup


### PR DESCRIPTION
For now we have this setup:
- To use CPD, projects will need to set some variables on their `Dangerfile`:
  - `@minimum_tokens, @language, @directory, @ssh, @target_branch`
  - if any of these variables is not set CDP will not run showing a warning
- To run on CI we need to install `pmd`: 
  - for projects using travis, we add `- brew install pmd` in `.travis.yml`
  - for projects using Jenkins, we add `- brew install pmd` in Jenkins script configuration

I am testing danger features [here](https://github.com/indigotech/br-schutz-app-ios/pull/597), the last warning is from CPD.

Depending on project CPD can turn in a bottleneck because it clones the repo to do comparison between feature branch and target branch. [Here](https://travis-ci.com/indigotech/br-schutz-app-ios/jobs/66442313#L3520) we can see that `danger` was executed in 41 seconds with CPD on this repo but I know that there are some huge repos (1GB+) :confused:

So what you guys think about this approach @felipesabino @melloflavio 

# Pending:

- [x] Install `pmd` on docker image
- [x] Remove temporary directory (`target-branch`) to avoid garbage on local runs
- [x] Check if `pmd` is not present on current build
- [x] Update `README` list with this check