### PR TITLE
Regex for todo check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -227,7 +227,7 @@ if @platform == "ios"
       File.foreach(file) do |line|
         line = line.gsub('\n','').strip
         # Warn developers things that need to be done
-        warn("`TODO` was added in `#{file}` at line `#{line}`") if line =~ /^(#\s*.*?|\/\/\s*.*?)(TO\s*.*?DO)/mi
+        warn("`TODO` was added in `#{file}` at line `#{line}`") if line =~ /(#\s*|\/\/\s*)(TO\s*DO|TO_DO)/mi
 
         ext = File.extname(file)
         case ext


### PR DESCRIPTION
# Regex for `todo` check was wrong

## Test [here](https://regex101.com/)
- Test text:
```
#define CATEGORIA_TODOS_ID @"";
#define CATEGORIA_SAUDEEBELEZA_CLINICAODONTOLOGICA_DESCRICAO @"Clínica Odontológica"
#define CATEGORIA_AUTOMOVEIS_MONTADORAS_DESCRICAO @"Montadoras"
// // Optional: set Google Analytics dispatch interval negative makes the data to be sent only with the disptach call. (Currently being done at SyncController)
#import "ProdutoCampanhaDetalhado.h"
// TODO erro - não continuar?
#define SUBCATEGORIA_TODOS_DESCRICAO @"Todos";
//Todos
#define CATEGORIA_AUTOMOVEIS_LOCADORAVEICULOS_DESCRICAO @"Locadora de veículos"
#define CATEGORIA_TODOS_DESCRICAO @"Todos"; # to_do
#define CATEGORIA_COMEREBEBER_RESTAURANTEPEIXESEFRUTOSDOMAR_DESCRICAO @"Restaurante de Peixes e frutos do mar" # to do
#define CATEGORIA_TODOS_IMAGE @"img-todos"; //todo
#define OBJETIVO_CONTADOR_TEXTO @"Caso não tenha recebido, aguarde o tempo indicado abaixo e solicite um novo código:" #todo
//           TODO
```
### Regex:
- Before: `/^(#\s*.*?|\/\/\s*.*?)(TO\s*.*?DO)/mig`
- After: `/(#\s*|\/\/\s*)(TO\s*DO|TO_DO)/mig`
obs.: flag `g` is needed to test on this test site

### Results:
Using the old regex every single line is a match

Can you check if I am missing something?